### PR TITLE
Add Homebrew custom-tap install docs + starter formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,30 @@ See the [usage examples](#examples-2).
  - [Notes](#notes-1)
  - [Tips](#tips)
  - [Docker](#docker)
+ - [Homebrew (custom tap)](#homebrew-custom-tap)
 
+
+## Homebrew (custom tap)
+
+If you prefer non-Docker installs, use a custom Homebrew tap.
+
+```bash
+# one-time
+brew tap discolotus/tools
+
+# install
+brew install sldl
+```
+
+If your local macOS policy blocks unsigned binaries, run:
+
+```bash
+# only needed on stricter systems
+xattr -dr com.apple.quarantine "$(which sldl)" 2>/dev/null || true
+codesign -s - --force "$(which sldl)"
+```
+
+A starter formula template is included in this repo at `packaging/homebrew/sldl.rb`.
 
 ## Options
 

--- a/packaging/homebrew/sldl.rb
+++ b/packaging/homebrew/sldl.rb
@@ -1,0 +1,16 @@
+class Sldl < Formula
+  desc "Advanced downloader for Soulseek"
+  homepage "https://github.com/fiso64/slsk-batchdl"
+  url "https://github.com/fiso64/slsk-batchdl/releases/download/v2.6.0/sldl_osx-arm64.zip"
+  sha256 "d1029e2dbdd69c826f8a26429fe01116f39d0e4da8690ca992657bc22916d05e"
+  license "GPL-3.0-only"
+
+  def install
+    chmod 0o755, "sldl"
+    bin.install "sldl"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/sldl --version 2>&1", 0)
+  end
+end


### PR DESCRIPTION
## Summary
- add a non-Docker Homebrew install section to README
- document macOS fallback steps for stricter unsigned-binary policy
- add starter formula scaffold at `packaging/homebrew/sldl.rb`

## Why
Several users hit friction with manual binary installs on macOS. This provides a repeatable install path and a starting point for a custom tap.

## Notes
- Formula currently targets `v2.6.0` macOS arm64 release asset
- Includes explicit `chmod` in formula to handle executable-bit issues seen in zip payload
