### PR TITLE
CI: macOS signed/notarized release workflow scaffold

### DIFF
--- a/.github/workflows/macos-sign-notarize.yml
+++ b/.github/workflows/macos-sign-notarize.yml
@@ -104,6 +104,18 @@ jobs:
           cd dist/osx-arm64 && /usr/bin/zip -r ../sldl_osx-arm64.zip ${APP_NAME}
           cd ../osx-x64 && /usr/bin/zip -r ../sldl_osx-x64.zip ${APP_NAME}
 
+      - name: Verify executable bit survives packaging
+        shell: bash
+        run: |
+          mkdir -p dist/verify/arm64 dist/verify/x64
+          unzip -q dist/sldl_osx-arm64.zip -d dist/verify/arm64
+          unzip -q dist/sldl_osx-x64.zip -d dist/verify/x64
+
+          test -x dist/verify/arm64/${APP_NAME} || { echo "ERROR: arm64 artifact lost executable bit"; ls -l dist/verify/arm64/${APP_NAME}; exit 1; }
+          test -x dist/verify/x64/${APP_NAME} || { echo "ERROR: x64 artifact lost executable bit"; ls -l dist/verify/x64/${APP_NAME}; exit 1; }
+
+          echo "Executable-bit check passed for both macOS artifacts."
+
       - name: Notarize zip artifacts
         if: ${{ secrets.APPLE_ID != '' && secrets.APPLE_APP_SPECIFIC_PASSWORD != '' && secrets.APPLE_TEAM_ID != '' }}
         env:

--- a/.github/workflows/macos-sign-notarize.yml
+++ b/.github/workflows/macos-sign-notarize.yml
@@ -69,13 +69,17 @@ jobs:
             -o dist/osx-x64
           chmod +x dist/osx-x64/${APP_NAME}
 
-      - name: Import Apple Developer ID certificate
-        if: ${{ secrets.APPLE_CERT_P12_BASE64 != '' && secrets.APPLE_CERT_PASSWORD != '' && secrets.APPLE_TEAM_ID != '' }}
+      - name: Import Apple Developer ID certificate (optional)
         env:
           APPLE_CERT_P12_BASE64: ${{ secrets.APPLE_CERT_P12_BASE64 }}
           APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
         shell: bash
         run: |
+          if [[ -z "$APPLE_CERT_P12_BASE64" || -z "$APPLE_CERT_PASSWORD" ]]; then
+            echo "Signing cert secrets not set; skipping certificate import."
+            exit 0
+          fi
+
           KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain-db"
           CERT_PATH="$RUNNER_TEMP/dev_id.p12"
 
@@ -89,11 +93,14 @@ jobs:
           security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$APPLE_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple: -s -k "" "$KEYCHAIN_PATH"
 
-      - name: Sign binaries (Developer ID)
-        if: ${{ secrets.APPLE_DEVELOPER_ID != '' }}
+      - name: Sign binaries (Developer ID, optional)
         env:
           APPLE_DEVELOPER_ID: ${{ secrets.APPLE_DEVELOPER_ID }}
         run: |
+          if [[ -z "$APPLE_DEVELOPER_ID" ]]; then
+            echo "APPLE_DEVELOPER_ID not set; skipping codesign."
+            exit 0
+          fi
           codesign --force --options runtime --timestamp --sign "$APPLE_DEVELOPER_ID" dist/osx-arm64/${APP_NAME}
           codesign --force --options runtime --timestamp --sign "$APPLE_DEVELOPER_ID" dist/osx-x64/${APP_NAME}
           codesign --verify --verbose=2 dist/osx-arm64/${APP_NAME}
@@ -116,13 +123,17 @@ jobs:
 
           echo "Executable-bit check passed for both macOS artifacts."
 
-      - name: Notarize zip artifacts
-        if: ${{ secrets.APPLE_ID != '' && secrets.APPLE_APP_SPECIFIC_PASSWORD != '' && secrets.APPLE_TEAM_ID != '' }}
+      - name: Notarize zip artifacts (optional)
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
+          if [[ -z "$APPLE_ID" || -z "$APPLE_APP_SPECIFIC_PASSWORD" || -z "$APPLE_TEAM_ID" ]]; then
+            echo "Notarization secrets not set; skipping notarization."
+            exit 0
+          fi
+
           xcrun notarytool submit dist/sldl_osx-arm64.zip \
             --apple-id "$APPLE_ID" \
             --team-id "$APPLE_TEAM_ID" \
@@ -135,9 +146,16 @@ jobs:
             --password "$APPLE_APP_SPECIFIC_PASSWORD" \
             --wait
 
-      - name: Staple notarization ticket (when available)
-        if: ${{ secrets.APPLE_ID != '' && secrets.APPLE_APP_SPECIFIC_PASSWORD != '' && secrets.APPLE_TEAM_ID != '' }}
+      - name: Staple notarization ticket (optional)
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
+          if [[ -z "$APPLE_ID" || -z "$APPLE_APP_SPECIFIC_PASSWORD" || -z "$APPLE_TEAM_ID" ]]; then
+            echo "Notarization secrets not set; skipping stapling."
+            exit 0
+          fi
           xcrun stapler staple dist/osx-arm64/${APP_NAME} || true
           xcrun stapler staple dist/osx-x64/${APP_NAME} || true
 

--- a/.github/workflows/macos-sign-notarize.yml
+++ b/.github/workflows/macos-sign-notarize.yml
@@ -1,0 +1,154 @@
+name: Build, sign and notarize macOS release artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version/tag to package (e.g. 2.6.1). Used for artifact names only."
+        required: false
+        type: string
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  macos-release:
+    runs-on: macos-latest
+    env:
+      DOTNET_NOLOGO: "true"
+      APP_NAME: sldl
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 6 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "6.0.x"
+
+      - name: Resolve version label
+        id: ver
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+            v="${GITHUB_REF_NAME#v}"
+          elif [[ -n "${{ inputs.version }}" ]]; then
+            v="${{ inputs.version }}"
+          else
+            v="dev-${GITHUB_RUN_NUMBER}"
+          fi
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          echo "Using version: $v"
+
+      - name: Restore
+        run: dotnet restore slsk-batchdl.sln
+
+      - name: Publish osx-arm64
+        run: |
+          dotnet publish slsk-batchdl/slsk-batchdl.csproj \
+            -c Release \
+            -r osx-arm64 \
+            --self-contained true \
+            /p:PublishSingleFile=true \
+            /p:PublishTrimmed=false \
+            /p:AssemblyName=${APP_NAME} \
+            -o dist/osx-arm64
+          chmod +x dist/osx-arm64/${APP_NAME}
+
+      - name: Publish osx-x64
+        run: |
+          dotnet publish slsk-batchdl/slsk-batchdl.csproj \
+            -c Release \
+            -r osx-x64 \
+            --self-contained true \
+            /p:PublishSingleFile=true \
+            /p:PublishTrimmed=false \
+            /p:AssemblyName=${APP_NAME} \
+            -o dist/osx-x64
+          chmod +x dist/osx-x64/${APP_NAME}
+
+      - name: Import Apple Developer ID certificate
+        if: ${{ secrets.APPLE_CERT_P12_BASE64 != '' && secrets.APPLE_CERT_PASSWORD != '' && secrets.APPLE_TEAM_ID != '' }}
+        env:
+          APPLE_CERT_P12_BASE64: ${{ secrets.APPLE_CERT_P12_BASE64 }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+        shell: bash
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain-db"
+          CERT_PATH="$RUNNER_TEMP/dev_id.p12"
+
+          echo "$APPLE_CERT_P12_BASE64" | base64 --decode > "$CERT_PATH"
+
+          security create-keychain -p "" "$KEYCHAIN_PATH"
+          security unlock-keychain -p "" "$KEYCHAIN_PATH"
+          security set-keychain-settings "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+
+          security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$APPLE_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple: -s -k "" "$KEYCHAIN_PATH"
+
+      - name: Sign binaries (Developer ID)
+        if: ${{ secrets.APPLE_DEVELOPER_ID != '' }}
+        env:
+          APPLE_DEVELOPER_ID: ${{ secrets.APPLE_DEVELOPER_ID }}
+        run: |
+          codesign --force --options runtime --timestamp --sign "$APPLE_DEVELOPER_ID" dist/osx-arm64/${APP_NAME}
+          codesign --force --options runtime --timestamp --sign "$APPLE_DEVELOPER_ID" dist/osx-x64/${APP_NAME}
+          codesign --verify --verbose=2 dist/osx-arm64/${APP_NAME}
+          codesign --verify --verbose=2 dist/osx-x64/${APP_NAME}
+
+      - name: Zip artifacts (preserve executable bit)
+        run: |
+          cd dist/osx-arm64 && /usr/bin/zip -r ../sldl_osx-arm64.zip ${APP_NAME}
+          cd ../osx-x64 && /usr/bin/zip -r ../sldl_osx-x64.zip ${APP_NAME}
+
+      - name: Notarize zip artifacts
+        if: ${{ secrets.APPLE_ID != '' && secrets.APPLE_APP_SPECIFIC_PASSWORD != '' && secrets.APPLE_TEAM_ID != '' }}
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          xcrun notarytool submit dist/sldl_osx-arm64.zip \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --wait
+
+          xcrun notarytool submit dist/sldl_osx-x64.zip \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --wait
+
+      - name: Staple notarization ticket (when available)
+        if: ${{ secrets.APPLE_ID != '' && secrets.APPLE_APP_SPECIFIC_PASSWORD != '' && secrets.APPLE_TEAM_ID != '' }}
+        run: |
+          xcrun stapler staple dist/osx-arm64/${APP_NAME} || true
+          xcrun stapler staple dist/osx-x64/${APP_NAME} || true
+
+      - name: Compute checksums
+        run: |
+          shasum -a 256 dist/sldl_osx-arm64.zip > dist/sldl_osx-arm64.zip.sha256
+          shasum -a 256 dist/sldl_osx-x64.zip > dist/sldl_osx-x64.zip.sha256
+          cat dist/*.sha256
+
+      - name: Upload workflow artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sldl-macos-${{ steps.ver.outputs.version }}
+          path: |
+            dist/sldl_osx-arm64.zip
+            dist/sldl_osx-x64.zip
+            dist/*.sha256
+
+      - name: Upload assets to GitHub Release
+        if: ${{ github.event_name == 'release' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/sldl_osx-arm64.zip
+            dist/sldl_osx-x64.zip
+            dist/*.sha256

--- a/README.md
+++ b/README.md
@@ -712,3 +712,27 @@ Example => Run `sldl` every Sunday at 1am, search for missing tracks from the sp
 ```
 
 [crontab.guru](https://crontab.guru/) could be used to help with the scheduling expression.
+
+## Maintainers: macOS signed/notarized release pipeline
+
+This repo includes a workflow scaffold at:
+
+- `.github/workflows/macos-sign-notarize.yml`
+
+It builds `sldl` for `osx-arm64` and `osx-x64`, preserves executable bit in zip artifacts, and supports Apple Developer ID signing + notarization when secrets are configured.
+
+### Required GitHub secrets
+
+- `APPLE_CERT_P12_BASE64` - base64 encoded Developer ID Application certificate (`.p12`)
+- `APPLE_CERT_PASSWORD` - password for the `.p12`
+- `APPLE_DEVELOPER_ID` - certificate subject, e.g. `Developer ID Application: Company, Inc. (TEAMID)`
+- `APPLE_ID` - Apple account used for notarization
+- `APPLE_TEAM_ID` - Apple developer team ID
+- `APPLE_APP_SPECIFIC_PASSWORD` - app-specific password for notarization
+
+### Triggering
+
+- Automatically on `release: published`
+- Manually via `workflow_dispatch`
+
+Without signing secrets, the workflow still builds artifacts for testing but skips signing/notarization steps.


### PR DESCRIPTION
## Summary
- add GitHub Actions scaffold to build macOS sldl artifacts for osx-arm64 and osx-x64
- preserve executable bit in packaged zip artifacts
- add optional Apple Developer ID signing + notarization steps (gated by secrets)
- upload assets to release when triggered from published release
- document required secrets and trigger behavior in README

## Why
Homebrew install works, but unsigned macOS artifacts can trigger first-run Gatekeeper/SIGKILL friction. This workflow establishes the release path needed to ship trusted artifacts and remove post-install workarounds.

## Notes
- signing/notarization steps are skipped automatically when secrets are not configured
- supports both release-published and manual workflow-dispatch triggers
